### PR TITLE
Refine PSF plan / type inference

### DIFF
--- a/docs/lit/examples/2-rotate.jl
+++ b/docs/lit/examples/2-rotate.jl
@@ -119,7 +119,7 @@ jim(result1, "Rotated image by π/6 (3-pass 1D)")
 jim(result1 - result2, "Difference images")
 
 
-### Adjoint
+# ### Adjoint
 
 # To ensure adjoint consistency between SPECT forward- and back-projection,
 # there is also an adjoint routine:
@@ -138,7 +138,7 @@ jim(adj1, "Adjoint image rotation (3-pass 1D)")
 # so one does not expect the output here to match the original image!
 
 
-### LinearMap
+# ### LinearMap
 
 # One can form a linear map corresponding to image rotation using `LinearMapAA`.
 # An operator like this may be useful

--- a/docs/lit/examples/2-rotate.jl
+++ b/docs/lit/examples/2-rotate.jl
@@ -61,10 +61,8 @@ isinteractive() ? jim(:prompt, true) : prompt(:draw);
 # The `plan` is a `Vector` of `PlanRotate` objects:
 # one for each thread.
 # (Parallelism is across slices for a 3D image volume.)
-# The number of threads defaults to `Threads.nthreads()`,
-# but one can select any number
-# and selecting more threads than number of cores
-# empirically can reduce computation time.
+# The number of threads defaults to `Threads.nthreads()`.
+
 
 # ### Example
 
@@ -78,11 +76,10 @@ jim(image, "Original image")
 
 # Now plan the rotation
 # by specifying
-# * the image size (must be square)
-# * the `DataType` used for the work arrays
-# * the (maximum) number of threads.
+# * the image size `nx` (it must be square, so `ny=nx` implicitly)
+# * the `DataType` used for the work arrays.
 
-plan2 = plan_rotate(size(image, 1); T, nthread = Threads.nthreads())
+plan2 = plan_rotate(size(image, 1); T)
 
 # Here are the internals for the plan for the first thread:
 
@@ -102,7 +99,7 @@ jim(result2, "Rotated image by π/6 (2D bilinear)")
 # included mainly for checking consistency
 # with the historical ASPIRE approach used in Matlab version of MIRT.
 
-plan1 = plan_rotate(size(image, 1); T, nthread = Threads.nthreads(), method=:one)
+plan1 = plan_rotate(size(image, 1); T, method=:one)
 
 # Here are the plan internals for the first thread:
 

--- a/docs/lit/examples/3-psf.jl
+++ b/docs/lit/examples/3-psf.jl
@@ -43,52 +43,64 @@ isinteractive() ? jim(:prompt, true) : prompt(:draw);
 # The `plan` is a `Vector` of `PlanPSF` objects:
 # one for each thread.
 # (Parallelism is across planes for a 3D image volume.)
-# The number of threads defaults to `Threads.nthreads()`,
-# but one can select any number
-# and selecting more threads than number of cores
-# empirically can reduce computation time.
+# The number of threads defaults to `Threads.nthreads()`.
+
 
 # ### Example
 
 # Start with a 3D image volume.
 
 T = Float32 # work with single precision to save memory
-nx = 64
+nx = 32
 nz = 30
 image = zeros(T, nx, nx, nz) # ny = nx required
-image[nx÷2, nx÷2, nz÷2] = 1
+image[1nx÷4, 1nx÷4, 3nz÷4] = 1
+image[2nx÷4, 2nx÷4, 2nz÷4] = 1
+image[3nx÷4, 3nx÷4, 1nz÷4] = 1
 jim(image, "Original image")
 
 
-# Create a synthetic depth-dependent PSF
-nx_psf = 17
+# Create a synthetic depth-dependent PSF for a single view
+
+function fake_psf(nx::Int, nx_psf::Int; factor::Real=0.9)
+    psf = zeros(Float32, nx_psf, nx_psf, nx)
+
+    for iy in 1:nx # depth-dependent blur
+        r = (-(nx_psf-1)÷2):((nx_psf-1)÷2)
+        r2 = abs2.((r / nx_psf) * iy.^0.9)
+        tmp = @. exp(-(r2 + r2') / 2)
+        psf[:,:,iy] = tmp / maximum(tmp)
+    end
+    return psf
+end
+
+nx_psf = 11
 nview = 1 # for simplicity in this illustration
 psf = zeros(nx_psf, nx_psf, nx, nview)
 
-psf[:] .= 1 # todo: refine
+psf[:,:,:,1] = fake_psf(nx, nx_psf)
+jim(psf, "PSF for each of $nx planes")
 
 
 # Now plan the PSF modeling
 # by specifying
 # * the image size (must be square)
 # * the PSF size: must be `nx_psf × nx_psf × nx × nview`
-# * the `DataType` used for the work arrays
-# * the (maximum) number of threads.
+# * the `DataType` used for the work arrays.
 
-plan = plan_rotate(nx, nz, nx_psf; T, nthread = Threads.nthreads())
+plan = plan_psf(nx, nz, nx_psf; T)
 
 # Here are the internals for the plan for the first thread:
 
 plan[1]
 
 
-# With this `plan` preallocated, now we can apply the depth-dependent PSF
+# With this `plan` pre-allocated, now we can apply the depth-dependent PSF
 # to the image volume (assumed already rotated here).
 
 result = similar(image) # allocate memory for the result
-# todo:
-# apply_psf!(result, image, plan) # mutates the first argument
-# jim(result, "After applying PSF")
+fft_conv!(result, image, psf[:,:,:,1], plan) # mutates the first argument
+jim(result, "After applying PSF")
 
 
 # ### Adjoint
@@ -97,8 +109,8 @@ result = similar(image) # allocate memory for the result
 # there is also an adjoint routine:
 
 adj = similar(result)
-# apply_psf_adj!(adj, result, plan
-# jim(adj, "Adjoint of PSF modeling")
+fft_conv_adj!(adj, result, psf[:,:,:,1], plan)
+jim(adj, "Adjoint of PSF modeling")
 
 
 # The adjoint is *not* the same as the inverse
@@ -112,18 +124,20 @@ adj = similar(result)
 
 using LinearMapsAA: LinearMapAA
 
-nx, nz, nx_psf = 20, 10, 5 # small size for illustration
-plan = plan_rotate(nx, nz, nx_psf; T, nthread = Threads.nthreads())
+nx, nz, nx_psf = 10, 7, 5 # small size for illustration
+psf3 = fake_psf(nx, nx_psf)
+plan = plan_psf(nx, nz, nx_psf; T)
 idim = (nx,nx,nz)
 odim = (nx,nx,nz)
-#forw! = (y,x) -> apply_psf!(y, x, plan)
-#back! = (x,y) -> apply_psf_adj!(x, y, plan)
-#A = LinearMapAA(forw!, back!, (prod(odim),prod(idim)); T, odim, idim)
+forw! = (y,x) -> fft_conv!(y, x, psf3, plan)
+back! = (x,y) -> fft_conv_adj!(x, y, psf3, plan)
+A = LinearMapAA(forw!, back!, (prod(odim),prod(idim)); T, odim, idim)
 
-#Afull = Matrix(A)
-#Aadj = Matrix(A')
-#jim(cat(dims=3, Afull, Aadj'), "Linear map for PSF modeling and its adjoint")
+Afull = Matrix(A)
+Aadj = Matrix(A')
+jim(cat(dims=3, Afull, Aadj'), "Linear map for PSF modeling and its adjoint")
 
 
-# The following verifies adjoint consistency:
-#@assert Afull ≈ Aadj'
+# The following check verifies adjoint consistency:
+
+@assert Afull ≈ Aadj'

--- a/docs/lit/examples/3-psf.jl
+++ b/docs/lit/examples/3-psf.jl
@@ -1,0 +1,129 @@
+#---------------------------------------------------------
+# # [SPECTrecon PSF](@id 3-psf)
+#---------------------------------------------------------
+
+# This page explains the PSF portion of the Julia package
+# [`SPECTrecon.jl`](https://github.com/JeffFessler/SPECTrecon.jl).
+
+# ### Setup
+
+# Packages needed here.
+
+using SPECTrecon
+using MIRTjim: jim, prompt
+using Plots: scatter, scatter!, plot!, default
+default(markerstrokecolor=:auto, markersize=3)
+
+# The following line is helpful when running this example.jl file as a script;
+# this way it will prompt user to hit a key after each figure is displayed.
+
+isinteractive() ? jim(:prompt, true) : prompt(:draw);
+
+# ### Overview
+
+# After rotating the image and the attenuation map,
+# second step in SPECT image forward projection
+# is to apply depth-dependent point spread function (PSF).
+# Each (rotated) image plane
+# is a certain distance from the SPECT detector
+# and must be convolved with the 2D PSF appropriate
+# for that plane.
+
+# Because SPECT has relatively poor spatial resolution,
+# the PSF is usually fairly wide,
+# so convolution using FFT operations
+# is typically more efficient
+# than direct spatial convolution.
+
+# Following other libraries like
+# [FFTW.jl](https://github.com/JuliaMath/FFTW.jl),
+# the PSF operations herein start with a `plan`
+# where work arrays are preallocated
+# for subsequent use.
+# The `plan` is a `Vector` of `PlanPSF` objects:
+# one for each thread.
+# (Parallelism is across planes for a 3D image volume.)
+# The number of threads defaults to `Threads.nthreads()`,
+# but one can select any number
+# and selecting more threads than number of cores
+# empirically can reduce computation time.
+
+# ### Example
+
+# Start with a 3D image volume.
+
+T = Float32 # work with single precision to save memory
+nx = 64
+nz = 30
+image = zeros(T, nx, nx, nz) # ny = nx required
+image[nx÷2, nx÷2, nz÷2] = 1
+jim(image, "Original image")
+
+
+# Create a synthetic depth-dependent PSF
+nx_psf = 17
+nview = 1 # for simplicity in this illustration
+psf = zeros(nx_psf, nx_psf, nx, nview)
+
+psf[:] .= 1 # todo: refine
+
+
+# Now plan the PSF modeling
+# by specifying
+# * the image size (must be square)
+# * the PSF size: must be `nx_psf × nx_psf × nx × nview`
+# * the `DataType` used for the work arrays
+# * the (maximum) number of threads.
+
+plan = plan_rotate(nx, nz, nx_psf; T, nthread = Threads.nthreads())
+
+# Here are the internals for the plan for the first thread:
+
+plan[1]
+
+
+# With this `plan` preallocated, now we can apply the depth-dependent PSF
+# to the image volume (assumed already rotated here).
+
+result = similar(image) # allocate memory for the result
+# todo:
+# apply_psf!(result, image, plan) # mutates the first argument
+# jim(result, "After applying PSF")
+
+
+# ### Adjoint
+
+# To ensure adjoint consistency between SPECT forward- and back-projection,
+# there is also an adjoint routine:
+
+adj = similar(result)
+# apply_psf_adj!(adj, result, plan
+# jim(adj, "Adjoint of PSF modeling")
+
+
+# The adjoint is *not* the same as the inverse
+# so one does not expect the output here to match the original image!
+
+
+# ### LinearMap
+
+# One can form a linear map corresponding to PSF modeling using `LinearMapAA`.
+# Perhaps the main purpose is simply for verifying adjoint correctness.
+
+using LinearMapsAA: LinearMapAA
+
+nx, nz, nx_psf = 20, 10, 5 # small size for illustration
+plan = plan_rotate(nx, nz, nx_psf; T, nthread = Threads.nthreads())
+idim = (nx,nx,nz)
+odim = (nx,nx,nz)
+#forw! = (y,x) -> apply_psf!(y, x, plan)
+#back! = (x,y) -> apply_psf_adj!(x, y, plan)
+#A = LinearMapAA(forw!, back!, (prod(odim),prod(idim)); T, odim, idim)
+
+#Afull = Matrix(A)
+#Aadj = Matrix(A')
+#jim(cat(dims=3, Afull, Aadj'), "Linear map for PSF modeling and its adjoint")
+
+
+# The following verifies adjoint consistency:
+#@assert Afull ≈ Aadj'

--- a/src/fft_convolve.jl
+++ b/src/fft_convolve.jl
@@ -52,11 +52,12 @@ end
     fft_conv(img, ker)
 Convolve `img` with `ker` using FFT
 """
-function fft_conv(img, ker)
+function fft_conv(img::AbstractMatrix{I}, ker::AbstractMatrix{K}) where {I <: Number, K <: Number}
+    T = promote_type(I, K, Float32)
     nx, nz = size(img)
     nx_psf = size(ker, 1)
-    plan = plan_psf(nx, nz, nx_psf; T = eltype(img), nthread = 1)[1]
-    output = similar(img)
+    plan = plan_psf(nx, nz, nx_psf; T, nthread = 1)[1]
+    output = similar(Matrix{T}, size(img))
     fft_conv!(output, img, ker, plan)
     return output
 end
@@ -64,14 +65,14 @@ end
 
 """
     fft_conv_adj!(output, img, ker, plan)
-Adjoint of convolving `img` with `ker` using FFT, and store the result in `output`
+Adjoint of convolving `img` with `ker` using FFT, storing the result in `output`.
 """
 function fft_conv_adj!(
     output::AbstractMatrix{<:RealU},
     img::AbstractMatrix{<:RealU},
     ker::AbstractMatrix{<:RealU},
-    plan::PlanPSF,
-    )
+    plan::PlanPSF{T},
+) where {T}
 
     @boundscheck size(output) == size(img) || throw("size output")
     @boundscheck size(img) == (plan.nx, plan.nz) || throw("size img")
@@ -84,8 +85,6 @@ function fft_conv_adj!(
     imfilterz!(plan)
     (M, N) = size(img)
     # adjoint of replicate padding
-    T = eltype(plan.workvecz)
-
     plan.workvecz .= zero(T)
     for i = 1:plan.padsize[1]
         plus2di!(plan.workvecz, plan.workmat, i)
@@ -121,11 +120,12 @@ end
     fft_conv_adj(img, ker)
 Adjoint of convolving `img` with `ker` using FFT
 """
-function fft_conv_adj(img, ker)
+function fft_conv_adj(img::AbstractMatrix{I}, ker::AbstractMatrix{K}) where {I <: Number, K <: Number}
+    T = promote_type(I, K, Float32)
     nx, nz = size(img)
     nx_psf = size(ker, 1)
-    plan = plan_psf(nx, nz, nx_psf; T = eltype(img), nthread = 1)[1]
-    output = similar(img)
+    plan = plan_psf(nx, nz, nx_psf; T, nthread = 1)[1]
+    output = similar(Matrix{T}, size(img))
     fft_conv_adj!(output, img, ker, plan)
     return output
 end

--- a/src/fft_convolve.jl
+++ b/src/fft_convolve.jl
@@ -55,7 +55,7 @@ Convolve `img` with `ker` using FFT
 function fft_conv(
     img::AbstractMatrix{I},
     ker::AbstractMatrix{K};
-    T = promote_type(I, K, Float32),
+    T::DataType = promote_type(I, K, Float32),
 ) where {I <: Number, K <: Number}
 
     nx, nz = size(img)
@@ -127,7 +127,7 @@ Adjoint of convolving `img` with `ker` using FFT
 function fft_conv_adj(
     img::AbstractMatrix{I},
     ker::AbstractMatrix{K};
-    T = promote_type(I, K, Float32),
+    T::DataType = promote_type(I, K, Float32),
 ) where {I <: Number, K <: Number}
 
     nx, nz = size(img)

--- a/src/fft_convolve.jl
+++ b/src/fft_convolve.jl
@@ -49,12 +49,12 @@ end
 
 
 """
-    fft_conv(img, ker)
+    fft_conv(img, ker; T)
 Convolve `img` with `ker` using FFT
 """
 function fft_conv(
     img::AbstractMatrix{I},
-    ker::AbstractMatrix{K},
+    ker::AbstractMatrix{K};
     T = promote_type(I, K, Float32),
 ) where {I <: Number, K <: Number}
 
@@ -121,14 +121,15 @@ end
 
 
 """
-    fft_conv_adj(img, ker)
+    fft_conv_adj(img, ker; T)
 Adjoint of convolving `img` with `ker` using FFT
 """
 function fft_conv_adj(
     img::AbstractMatrix{I},
-    ker::AbstractMatrix{K},
+    ker::AbstractMatrix{K};
     T = promote_type(I, K, Float32),
 ) where {I <: Number, K <: Number}
+
     nx, nz = size(img)
     nx_psf = size(ker, 1)
     plan = plan_psf(nx, nz, nx_psf; T, nthread = 1)[1]
@@ -147,7 +148,7 @@ function fft_conv!(
     image3::AbstractArray{<:RealU,3},
     ker3::AbstractArray{<:RealU,3},
     plans::Vector{<:PlanPSF},
-    )
+)
 
     size(output) == size(image3) || throw(DimensionMismatch())
 

--- a/src/plan-psf.jl
+++ b/src/plan-psf.jl
@@ -125,7 +125,7 @@ end
 """
     show(io::IO, mime::MIME"text/plain", vp::Vector{<:PlanPSF})
 """
-function Base.show(io::IO, mime::MIME"text/plain", vp::Vector{PlanPSF{T}}) where {T}
+function Base.show(io::IO, mime::MIME"text/plain", vp::Vector{<: PlanPSF})
     t = typeof(vp)
     println(io, length(vp), "-element ", t, " with N=", vp[1].nx)
 #   show(io, mime, vp[1])

--- a/src/rotatez.jl
+++ b/src/rotatez.jl
@@ -1,6 +1,7 @@
 # rotatez.jl
 
 export imrotate!, imrotate_adj!
+export imrotate, imrotate_adj
 
 using LinearInterpolators: LinearSpline
 using LinearInterpolators: SparseInterpolator, AffineTransform2D, rotate
@@ -333,8 +334,8 @@ function imrotate!(
     output::AbstractMatrix{<:RealU},
     img::AbstractMatrix{<:RealU},
     θ::RealU,
-    plan::PlanRotate{<:Number,RotateMode{:two}},
-)
+    plan::PlanRotate{T,RotateMode{:two}},
+) where {T}
 
     @boundscheck size(output) == size(img) || throw("size")
     @boundscheck size(img, 1) == size(img, 2) || throw("row != col")
@@ -346,7 +347,6 @@ function imrotate!(
 
     N = size(img, 1) # M = N!
 
-    T = eltype(img)
     ker = LinearSpline(T)
     rows = size(plan.workmat2)
     cols = size(plan.workmat1)
@@ -370,8 +370,13 @@ in counter-clockwise direction (opposite to `imrotate` in Julia)
 using either 2d linear interpolation (for `:two`)
 or 3-pass 1D interpolation (for `:one`)
 """
-function imrotate(img::AbstractMatrix{T}, θ::RealU; method::Symbol=:two) where {T <: RealU}
-    output = similar(img)
+function imrotate(
+    img::AbstractMatrix{I},
+    θ::RealU;
+    method::Symbol=:two,
+    T::DataType = promote_type(I, Float32),
+) where {I <: Number}
+    output = similar(Matrix{T}, size(img))
     plan = plan_rotate(size(img, 1); T, nthread = 1, method)[1]
     imrotate!(output, img, θ, plan)
     return output
@@ -388,15 +393,14 @@ function imrotate_adj!(
     output::AbstractMatrix{<:RealU},
     img::AbstractMatrix{<:RealU},
     θ::RealU,
-    plan::PlanRotate{<:Number,RotateMode{:two}},
-)
+    plan::PlanRotate{T,RotateMode{:two}},
+) where {T}
 
     @boundscheck size(output) == size(img) || throw("size")
     @boundscheck size(img, 1) == size(img, 2) || throw("row != col")
 
     N = size(img, 1) # M = N!
 
-    T = eltype(img)
     ker = LinearSpline(T)
     rows = size(plan.workmat2)
     cols = size(plan.workmat1)
@@ -419,8 +423,13 @@ The adjoint of rotating an image by angle θ (must be within 0 to 2π)
 in counter-clockwise direction (opposite to `imrotate` in Julia)
 using either 2d linear interpolations or 3-pass 1D interpolation.
 """
-function imrotate_adj(img::AbstractMatrix{T}, θ::RealU; method::Symbol=:two) where {T <: RealU}
-    output = similar(img)
+function imrotate_adj(
+    img::AbstractMatrix{I},
+    θ::RealU;
+    method::Symbol=:two,
+    T::DataType = promote_type(I, Float32),
+) where {I <: Number}
+    output = similar(Matrix{T}, size(img))
     plan = plan_rotate(size(img, 1); T, nthread = 1, method)[1]
     imrotate_adj!(output, img, θ, plan)
     return output

--- a/src/spectplan.jl
+++ b/src/spectplan.jl
@@ -76,8 +76,7 @@ struct SPECTplan{T}
         nz_psf = size(psfs, 2)
         nview = size(psfs, 4)
         (isodd(nx_psf) && isodd(nz_psf)) || throw("non-odd size psfs")
-        all(mapslices(x -> x == transpose(x), psfs, dims = [1, 2])) || throw("asym. psf tran.")
-        all(mapslices(x -> x == reverse(x), psfs, dims = [1, 2])) || throw("asym. psf rever.")
+        all(mapslices(x -> x == reverse(x, dims=:), psfs, dims = [1, 2])) || throw("asym. psf")
 
         # check interpidx
         (interpmeth === :one || interpmeth === :two) || throw("bad interpmeth")

--- a/test/adjoint-fftconv.jl
+++ b/test/adjoint-fftconv.jl
@@ -8,6 +8,15 @@ using LinearMapsAA: LinearMapAA
 using Test: @test, @testset, @inferred
 
 
+@testset "plan_psf" begin
+    plan = plan_psf(10, 10, 5)
+    show(isinteractive() ? stdout : devnull, "text/plain", plan)
+    show(isinteractive() ? stdout : devnull, "text/plain", plan[1])
+    @test sizeof(plan) isa Int
+    @test sizeof(plan[1]) isa Int
+end
+
+
 @testset "fftconv" begin
     img = randn(Float32, 12, 8)
     ker = rand(Float64, 7, 7)
@@ -15,14 +24,6 @@ using Test: @test, @testset, @inferred
     ker /= sum(ker)
     out = @inferred fft_conv(img, ker)
     @test eltype(out) == Float64
-end
-
-
-@testset "fftconv" begin
-    plan = plan_psf(10, 10, 5)
-    show(stdout, "text/plain", plan)
-    show(stdout, "text/plain", plan[1])
-    @test sizeof(plan) isa Int
 end
 
 

--- a/test/adjoint-fftconv.jl
+++ b/test/adjoint-fftconv.jl
@@ -3,20 +3,27 @@
 
 using SPECTrecon: fft_conv, fft_conv_adj
 using LinearMapsAA: LinearMapAA
-using Test: @test, @testset
+using Test: @test, @testset, @inferred
+
+
+@testset "fftconv" begin
+    img = randn(Float32, 12, 8)
+    ker = rand(Float64, 7, 7)
+    ker = ker .+ reverse(ker, dims=:)
+    ker /= sum(ker)
+    out = @inferred fft_conv(img, ker)
+    @test eltype(out) == Float64
+end
 
 
 @testset "adjoint-fftconv" begin
-    M = 40
-    N = 24
+    M = 20
+    N = 14
     T = Float32
-    testnum = 20
-    # test with different kernels
-    for i = 1:testnum
+    for i = 1:4 # test with different kernels
         img = randn(T, M, N)
-        ker = rand(T, 7, 7)
-        ker = ker .+ reverse(ker)
-        ker = ker .+ ker'
+        ker = rand(T, 5, 5)
+        ker = ker .+ reverse(ker, dims=:)
         ker /= sum(ker)
 
         idim = (M, N)

--- a/test/adjoint-rotate.jl
+++ b/test/adjoint-rotate.jl
@@ -9,10 +9,14 @@ using Test: @test, @testset
 
 
 @testset "rotate" begin
-    plan = plan_rotate(10)
+    nx = 10
+    plan = plan_rotate(nx)
     show(stdout, "text/plain", plan)
     show(stdout, "text/plain", plan[1])
     @test sizeof(plan) isa Int
+
+    out = @inferred imrotate(ones(Int,nx,nx), π/4)
+    @test eltype(out) == Float32
 end
 
 

--- a/test/fftconv.jl
+++ b/test/fftconv.jl
@@ -1,11 +1,12 @@
-# adjoint-fftconv.jl
-# test adjoint consistency for FFT convolution methods on very small case
+# fftconv.jl
+# test FFT-based convolution and
+# adjoint consistency for FFT convolution methods on very small case
 
 using SPECTrecon: plan_psf
 using SPECTrecon: fft_conv!, fft_conv_adj!, fft_conv_adj2!
 using SPECTrecon: fft_conv, fft_conv_adj
 using LinearMapsAA: LinearMapAA
-using Test: @test, @testset, @inferred
+using Test: @test, @testset, @test_throws, @inferred
 
 
 @testset "plan_psf" begin
@@ -20,10 +21,11 @@ end
 @testset "fftconv" begin
     img = randn(Float32, 12, 8)
     ker = rand(Float64, 7, 7)
-    ker = ker .+ reverse(ker, dims=:)
-    ker /= sum(ker)
-    out = @inferred fft_conv(img, ker)
+    ker_sym = ker .+ reverse(ker, dims=:)
+    ker_sym /= sum(ker_sym)
+    out = @inferred fft_conv(img, ker_sym)
     @test eltype(out) == Float64
+    @test_throws String fft_conv(img, ker)
 end
 
 
@@ -61,6 +63,6 @@ end
         back = img -> fft_conv_adj(img, ker)
 
         A = LinearMapAA(forw, back, (prod(odim), prod(idim)); T, odim, idim)
-        @test Matrix(A') ≈ Matrix(A)' # todo
+        @test Matrix(A') ≈ Matrix(A)'
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Test: @test, @testset, detect_ambiguities
 
 include("helper.jl")
 include("rotatez.jl")
-include("adjoint-fftconv.jl")
+include("fftconv.jl")
 include("adjoint-rotate.jl")
 include("adjoint-project.jl")
 


### PR DESCRIPTION
This makes the PSF plan a concrete type.
Also adds some initial type inference checks.
And generalizes the allocating versions so that input image can be any Number type.
And some documentation for the PSF part.