### PR TITLE
Rectangular PSF sizes

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+ImagePhantoms = "71a99df6-f52c-4da1-bd2a-69d6f37f3252"
 LinearMapsAA = "599c1a8e-b958-11e9-0d14-b1e6b2ecea07"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 MIRTjim = "170b2178-6dee-4cb0-8729-b3e8b57834cc"
@@ -12,6 +13,7 @@ UnitfulRecipes = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 [compat]
 Distributions = "0.25"
 Documenter = "0.27.7"
+ImagePhantoms = "0.0.5"
 LinearMapsAA = "0.7"
 Literate = "2.9.3"
 MIRTjim = "0.13"

--- a/docs/lit/examples/1-overview.jl
+++ b/docs/lit/examples/1-overview.jl
@@ -99,7 +99,7 @@ size(psfs)
 
 # Plan the PSF modeling (see `3-psf.jl`)
 
-plan = plan_psf(nx, nz, px)
+plan = plan_psf( ; nx, nz, px)
 
 
 # ### Basic SPECT forward projection

--- a/docs/lit/examples/1-overview.jl
+++ b/docs/lit/examples/1-overview.jl
@@ -82,9 +82,9 @@ jim(mid3(xtrue), "Middle slices of x")
 # ### PSF
 
 # Create a synthetic depth-dependent PSF for a single view
-nx_psf = 11
-psf1 = psf_gauss( ; nx, nx_psf, fwhm_end = 6)
-jim(psf1, "PSF for each of $nx planes")
+px = 11
+psf1 = psf_gauss( ; ny, px, fwhm_end = 6)
+jim(psf1, "PSF for each of $ny planes")
 
 
 # In general the PSF can vary from view to view
@@ -99,7 +99,7 @@ size(psfs)
 
 # Plan the PSF modeling (see `3-psf.jl`)
 
-plan = plan_psf(nx, nz, nx_psf)
+plan = plan_psf(nx, nz, px)
 
 
 # ### Basic SPECT forward projection

--- a/docs/lit/examples/3-psf.jl
+++ b/docs/lit/examples/3-psf.jl
@@ -74,7 +74,7 @@ jim(psf, "PSF for each of $nx planes")
 # * the PSF size: must be `px × pz × ny × nview`
 # * the `DataType` used for the work arrays.
 
-plan = plan_psf(nx, nz, px; T)
+plan = plan_psf( ; nx, nz, px, T)
 
 # Here are the internals for the plan for the first thread:
 
@@ -112,7 +112,7 @@ using LinearMapsAA: LinearMapAA
 
 nx, nz, px = 10, 7, 5 # small size for illustration
 psf3 = psf_gauss( ; ny, px)
-plan = plan_psf(nx, nz, px; T)
+plan = plan_psf( ; nx, nz, px, T)
 idim = (nx,nx,nz)
 odim = (nx,nx,nz)
 forw! = (y,x) -> fft_conv!(y, x, psf3, plan)

--- a/docs/lit/examples/3-psf.jl
+++ b/docs/lit/examples/3-psf.jl
@@ -62,19 +62,19 @@ jim(image, "Original image")
 
 # Create a synthetic gaussian depth-dependent PSF for a single view
 
-nx_psf = 11
+px = 11
 nview = 1 # for simplicity in this illustration
-psf = repeat(psf_gauss( ; nx, nx_psf), 1, 1, 1, nview)
+psf = repeat(psf_gauss( ; ny, px), 1, 1, 1, nview)
 jim(psf, "PSF for each of $nx planes")
 
 
 # Now plan the PSF modeling
 # by specifying
 # * the image size (must be square)
-# * the PSF size: must be `nx_psf × nx_psf × nx × nview`
+# * the PSF size: must be `px × pz × ny × nview`
 # * the `DataType` used for the work arrays.
 
-plan = plan_psf(nx, nz, nx_psf; T)
+plan = plan_psf(nx, nz, px; T)
 
 # Here are the internals for the plan for the first thread:
 
@@ -110,9 +110,9 @@ jim(adj, "Adjoint of PSF modeling")
 
 using LinearMapsAA: LinearMapAA
 
-nx, nz, nx_psf = 10, 7, 5 # small size for illustration
-psf3 = psf_gauss( ; nx, nx_psf)
-plan = plan_psf(nx, nz, nx_psf; T)
+nx, nz, px = 10, 7, 5 # small size for illustration
+psf3 = psf_gauss( ; ny, px)
+plan = plan_psf(nx, nz, px; T)
 idim = (nx,nx,nz)
 odim = (nx,nx,nz)
 forw! = (y,x) -> fft_conv!(y, x, psf3, plan)

--- a/docs/lit/examples/4-mlem.jl
+++ b/docs/lit/examples/4-mlem.jl
@@ -46,9 +46,9 @@ jim(mid3(xtrue), "Middle slices of xtrue")
 # ### PSF
 
 # Create a synthetic depth-dependent PSF for a single view
-nx_psf = 11
-psf1 = psf_gauss( ; nx, nx_psf)
-jim(psf1, "PSF for each of $nx planes")
+px = 11
+psf1 = psf_gauss( ; ny, px)
+jim(psf1, "PSF for each of $ny planes")
 
 
 # In general the PSF can vary from view to view

--- a/docs/lit/examples/5-2d.jl
+++ b/docs/lit/examples/5-2d.jl
@@ -1,0 +1,181 @@
+#---------------------------------------------------------
+# # [SPECTrecon 2D use](@id 5-2d)
+#---------------------------------------------------------
+
+# This page describes how to perform 2D SPECT forward and back-projection
+# using the Julia package
+# [`SPECTrecon`](https://github.com/JeffFessler/SPECTrecon.jl).
+
+
+# ### Setup
+
+# Packages needed here.
+
+using SPECTrecon
+using MIRTjim: jim, prompt
+using ImagePhantoms: shepp_logan, SheppLoganEmis
+using LinearAlgebra: mul!
+using LinearMapsAA: LinearMapAA
+using Plots: plot, default; default(markerstrokecolor=:auto)
+
+# The following line is helpful when running this example.jl file as a script;
+# this way it will prompt user to hit a key after each figure is displayed.
+
+isinteractive() ? jim(:prompt, true) : prompt(:draw);
+
+
+# ### Overview
+
+# Real SPECT systems are inherently 3D imaging systems,
+# but for the purpose of prototyping algorithms
+# it can be useful to work with 2D simulations.
+
+# Currently, "2D" here means a 3D array with `nz=1`,
+# i.e., a single slice.
+# The key to working with a single slice
+# is that the package allows the PSFs
+# to have rectangular support `px × pz`
+# where `pz = 1`, i.e., no blur along the axial (z) direction.
+
+
+# ### Example
+
+# Start with a simple 2D digital phantom.
+
+T = Float32
+nx,ny,nz = 128,128,1
+xtrue = T.(shepp_logan(nx, SheppLoganEmis()))
+xtrue = reshape(xtrue, nx, ny, 1) # 3D array with nz=1
+jim(xtrue, "xtrue: SheppLoganEmis with size $(size(xtrue))")
+
+
+# ### PSF
+
+# Create a synthetic depth-dependent PSF for a single view
+px,pz = 11,1 # pz=1 is crucial for 2D work
+psf1 = psf_gauss( ; ny, px, pz, fwhm_start = 1, fwhm_end = 4) # (px,pz,ny)
+tmp = reshape(psf1, px, ny) / maximum(psf1) # (px,ny)
+hx = (px-1)÷2
+plot(-hx:hx, tmp[:,[1:9:end-10;end]], markershape=:o, label="",
+    title = "Depth-dependent PSF profiles",
+    xtick = [-hx, -2, 0, 2, hx], # (-1:1) .* ((px-1)÷2),
+    ytick = [0; round.(tmp[hx+1,end] * [0.5,1], digits=2); 0.5; 1],
+)
+prompt()
+
+
+# In general the PSF can vary from view to view
+# due to non-circular detector orbits.
+# For simplicity, here we illustrate the case
+# where the PSF is the same for every view.
+
+nview = 80
+psfs = repeat(psf1, 1, 1, 1, nview)
+size(psfs)
+
+
+# ### Basic SPECT forward projection
+
+# Here is a simple illustration
+# of a SPECT forward projection operation.
+# (This is a memory inefficient way to do it!)
+
+dy = 4 # transaxial pixel size in mm
+mumap = zeros(T, size(xtrue)) # μ-map just zero for illustration here
+views = project(xtrue, mumap, psfs, dy) # [nx,1,nview]
+sino = reshape(views, nx, nview)
+size(sino)
+
+
+# Display the calculated (i.e., simulated) projection views
+
+jim(sino, "Sinogram")
+
+
+# ### Basic SPECT back projection
+
+# This illustrates an "unfiltered backprojection"
+# that leads to a very blurry image
+# (again, with a simple memory inefficient usage).
+
+# First, back-project two "rays"
+# to illustrate the depth-dependent PSF.
+sino1 = zeros(T, nx, nview)
+sino1[nx÷2, nview÷5] = 1
+sino1[nx÷2, 1] = 1
+sino1 = reshape(sino1, nx, nz, nview)
+back1 = backproject(sino1, mumap, psfs, dy)
+jim(back1, "Back-projection of two rays")
+
+
+# Now back-project all the views of the phantom.
+
+back = backproject(views, mumap, psfs, dy)
+jim(back, "Back-projection of ytrue")
+
+
+# ### Memory efficiency
+
+# For iterative reconstruction,
+# one must do forward and back-projection repeatedly.
+# It is more efficient to pre-allocate work arrays
+# for those operations,
+# instead of repeatedly making system calls.
+
+# Here we illustrate the memory efficient versions
+# that are recommended for iterative SPECT reconstruction.
+
+# First construction the SPECT plan.
+
+#viewangle = (0:(nview-1)) * 2π # default
+plan = SPECTplan(mumap, psfs, dy; T)
+
+# Mutating version of forward projection:
+
+tmp = Array{T}(undef, nx, nz, nview)
+project!(tmp, xtrue, plan)
+@assert tmp == views
+
+
+# Mutating version of back-projection:
+
+tmp = Array{T}(undef, nx, ny, nz)
+backproject!(tmp, views, plan)
+@assert tmp == back
+
+
+# ### Using `LinearMapsAA`
+
+# Calling `project!` and `backproject!` repeatedly
+# leads to application-specific code.
+# More general code uses the fact that SPECT projection and back-projection
+# are linear operations,
+# so we use `LinearMapAA` to define a "system matrix" for these operations.
+
+forw! = (y,x) -> project!(y, x, plan)
+back! = (x,y) -> backproject!(x, y, plan)
+idim = (nx,ny,nz)
+odim = (nx,nz,nview)
+A = LinearMapAA(forw!, back!, (prod(odim),prod(idim)); T, odim, idim)
+
+# Simple forward and back-projection:
+@assert A * xtrue == views
+@assert A' * views == back
+
+# Mutating version:
+tmp = Array{T}(undef, nx, nz, nview)
+mul!(tmp, A, xtrue)
+@assert tmp == views
+tmp = Array{T}(undef, nx, ny, nz)
+mul!(tmp, A', views)
+@assert tmp == back
+
+
+# ### Gram matrix impulse response
+
+points = zeros(T, nx, ny, nz)
+points[nx÷2,ny÷2,1] = 1
+points[3nx÷4,ny÷4,1] = 1
+
+impulse = A' * (A * points)
+jim(impulse, "Impulse response of A'A")

--- a/src/fft_convolve.jl
+++ b/src/fft_convolve.jl
@@ -33,7 +33,8 @@ function fft_conv!(
 )
     @boundscheck size(output) == size(img) || throw("size output")
     @boundscheck size(img) == (plan.nx, plan.nz) || throw("size img")
-    @boundscheck size(ker) == (plan.px, plan.pz) || throw("size ker")
+    @boundscheck size(ker) == (plan.px, plan.pz) ||
+        throw("size ker $(size(ker)) $(plan.px) $(plan.pz)")
 #   @boundscheck size(ker, 1) == size(ker, 2) || throw("size ker") # todo
 
     # filter the image with a kernel, using replicate padding and fft convolution
@@ -65,7 +66,7 @@ function fft_conv(
     ker ≈ reverse(ker, dims=:) || throw("asymmetric kernel")
     nx, nz = size(img)
     px, pz = size(ker)
-    plan = plan_psf(nx, nz, px; pz, T, nthread = 1)[1]
+    plan = plan_psf( ; nx, nz, px, pz, T, nthread = 1)[1]
     output = similar(Matrix{T}, size(img))
     fft_conv!(output, img, ker, plan)
     return output
@@ -85,8 +86,8 @@ function fft_conv_adj!(
 
     @boundscheck size(output) == size(img) || throw("size output")
     @boundscheck size(img) == (plan.nx, plan.nz) || throw("size img")
-    @boundscheck size(ker) == (plan.px,plan.pz) || throw("size ker")
-#   @boundscheck size(ker, 1) == size(ker, 2) || throw("size ker") # todo
+    @boundscheck size(ker) == (plan.px, plan.pz) ||
+        throw("size ker $(size(ker)) $(plan.px) $(plan.pz)")
 
     padzero!(plan.img_compl, img, plan.padsize) # pad the image with zeros
     pad2sizezero!(plan.ker_compl, ker, size(plan.ker_compl)) # pad the kernel with zeros
@@ -140,7 +141,7 @@ function fft_conv_adj(
     ker ≈ reverse(ker, dims=:) || throw("asymmetric kernel")
     nx, nz = size(img)
     px, pz = size(ker)
-    plan = plan_psf(nx, nz, px; pz, T, nthread = 1)[1]
+    plan = plan_psf( ; nx, nz, px, pz, T, nthread = 1)[1]
     output = similar(Matrix{T}, size(img))
     fft_conv_adj!(output, img, ker, plan)
     return output
@@ -149,7 +150,7 @@ end
 
 """
     fft_conv!(output, image3, ker3, plans)
-In-place version of convolving a 3D `image3`
+Mutating version of convolving a 3D `image3`
 with a set of 2D symmetric kernels
 stored in 3D array `ker3`
 using `foreach`.
@@ -206,7 +207,7 @@ end
 
 """
     fft_conv_adj2!(output, image2, ker3, plans)
-In-place version of adjoint of convolving a 2D `image2`
+Mutating version of adjoint of convolving a 2D `image2`
 with each 2D kernel in the 3D array `ker3`.
 """
 function fft_conv_adj2!(

--- a/src/fft_convolve.jl
+++ b/src/fft_convolve.jl
@@ -35,20 +35,17 @@ function fft_conv!(
     @boundscheck size(img) == (plan.nx, plan.nz) || throw("size img")
     @boundscheck size(ker) == (plan.px, plan.pz) ||
         throw("size ker $(size(ker)) $(plan.px) $(plan.pz)")
-#   @boundscheck size(ker, 1) == size(ker, 2) || throw("size ker") # todo
 
-    # filter the image with a kernel, using replicate padding and fft convolution
+    # filter image with a kernel, using replicate padding and fft convolution
     padrepl!(plan.img_compl, img, plan.padsize)
 
-    pad2sizezero!(plan.ker_compl, ker, size(plan.ker_compl)) # pad the kernel with zeros
+    pad2sizezero!(plan.ker_compl, ker, size(plan.ker_compl)) # zero pad kernel
 
     imfilterz!(plan)
 
     (M, N) = size(img)
-    copyto!(output, # todo: why only 2 of 4 padsize values used here?
-         (@view plan.workmat[plan.padsize[1]+1:plan.padsize[1]+M,
-                             plan.padsize[3]+1:plan.padsize[3]+N]),
-    )
+    copyto!(output, (@view plan.workmat[plan.padsize[1] .+ (1:M),
+                                        plan.padsize[3] .+ (1:N)]))
     return output
 end
 

--- a/src/fft_convolve.jl
+++ b/src/fft_convolve.jl
@@ -33,8 +33,8 @@ function fft_conv!(
 )
     @boundscheck size(output) == size(img) || throw("size output")
     @boundscheck size(img) == (plan.nx, plan.nz) || throw("size img")
-    @boundscheck size(ker, 1) == plan.nx_psf || throw("size nx_psf")
-    @boundscheck size(ker, 1) == size(ker, 2) || throw("size ker")
+    @boundscheck size(ker) == (plan.px, plan.pz) || throw("size ker")
+#   @boundscheck size(ker, 1) == size(ker, 2) || throw("size ker") # todo
 
     # filter the image with a kernel, using replicate padding and fft convolution
     padrepl!(plan.img_compl, img, plan.padsize)
@@ -44,7 +44,7 @@ function fft_conv!(
     imfilterz!(plan)
 
     (M, N) = size(img)
-    copyto!(output,
+    copyto!(output, # todo: why only 2 of 4 padsize values used here?
          (@view plan.workmat[plan.padsize[1]+1:plan.padsize[1]+M,
                              plan.padsize[3]+1:plan.padsize[3]+N]),
     )
@@ -64,8 +64,8 @@ function fft_conv(
 
     ker ≈ reverse(ker, dims=:) || throw("asymmetric kernel")
     nx, nz = size(img)
-    nx_psf = size(ker, 1)
-    plan = plan_psf(nx, nz, nx_psf; T, nthread = 1)[1]
+    px, pz = size(ker)
+    plan = plan_psf(nx, nz, px; pz, T, nthread = 1)[1]
     output = similar(Matrix{T}, size(img))
     fft_conv!(output, img, ker, plan)
     return output
@@ -85,8 +85,8 @@ function fft_conv_adj!(
 
     @boundscheck size(output) == size(img) || throw("size output")
     @boundscheck size(img) == (plan.nx, plan.nz) || throw("size img")
-    @boundscheck size(ker, 1) == plan.nx_psf || throw("size nx_psf")
-    @boundscheck size(ker, 1) == size(ker, 2) || throw("size ker")
+    @boundscheck size(ker) == (plan.px,plan.pz) || throw("size ker")
+#   @boundscheck size(ker, 1) == size(ker, 2) || throw("size ker") # todo
 
     padzero!(plan.img_compl, img, plan.padsize) # pad the image with zeros
     pad2sizezero!(plan.ker_compl, ker, size(plan.ker_compl)) # pad the kernel with zeros
@@ -139,8 +139,8 @@ function fft_conv_adj(
 
     ker ≈ reverse(ker, dims=:) || throw("asymmetric kernel")
     nx, nz = size(img)
-    nx_psf = size(ker, 1)
-    plan = plan_psf(nx, nz, nx_psf; T, nthread = 1)[1]
+    px, pz = size(ker)
+    plan = plan_psf(nx, nz, px; pz, T, nthread = 1)[1]
     output = similar(Matrix{T}, size(img))
     fft_conv_adj!(output, img, ker, plan)
     return output

--- a/src/helper.jl
+++ b/src/helper.jl
@@ -114,8 +114,19 @@ Base.@propagate_inbounds function fftshift2!(
     dst::AbstractMatrix,
     src::AbstractMatrix,
 )
-    @boundscheck (iseven(size(src, 1)) && iseven(size(src, 2))) || throw("odd")
     @boundscheck size(src) == size(dst) || throw("size")
+
+    if size(src,2) == 1
+        @boundscheck iseven(size(src, 1)) || throw("odd $(size(src))")
+        m = size(src,1) ÷ 2
+        for i = 1:m
+            @inbounds dst[i, 1] = src[m+i, 1]
+            @inbounds dst[i+m, 1] = src[i, 1]
+        end
+        return dst
+    end
+
+    @boundscheck (iseven(size(src, 1)) && iseven(size(src, 2))) || throw("odd")
     m, n = div.(size(src), 2)
     for j = 1:n, i = 1:m
         @inbounds dst[i, j] = src[m+i, n+j]

--- a/src/helper.jl
+++ b/src/helper.jl
@@ -8,10 +8,10 @@ using FFTW
 
 
 Power2 = x -> 2^(ceil(Int, log2(x)))
-_padup(nx, nx_psf) = ceil(Int, (Power2(nx + nx_psf - 1) - nx) / 2)
-_paddown(nx, nx_psf) = floor(Int, (Power2(nx + nx_psf - 1) - nx) / 2)
-_padleft(nz, nz_psf) = ceil(Int, (Power2(nz + nz_psf - 1) - nz) / 2)
-_padright(nz, nz_psf) = floor(Int, (Power2(nz + nz_psf - 1) - nz) / 2)
+_padup(nx, px)    =  ceil(Int, (Power2(nx + px - 1) - nx) / 2)
+_paddown(nx, px)  = floor(Int, (Power2(nx + px - 1) - nx) / 2)
+_padleft(nz, pz)  =  ceil(Int, (Power2(nz + pz - 1) - nz) / 2)
+_padright(nz, pz) = floor(Int, (Power2(nz + pz - 1) - nz) / 2)
 
 
 """

--- a/src/plan-psf.jl
+++ b/src/plan-psf.jl
@@ -5,13 +5,13 @@ import AbstractFFTs
 import FFTW
 
 """
-    PlanPSF{T,Tf,Ti}(nx::Int, nz::Int, px::Int; pz::Int, T::DataType)
+    PlanPSF{T,Tf,Ti}( ; nx::Int, nz::Int, px::Int, pz::Int, T::DataType)
 Struct for storing work arrays and factors for 2D convolution for one thread.
 Each PSF is `px × pz`
 - `T` datatype of work arrays (subtype of `AbstractFloat`)
-- `nx::Int` (`ny` implicitly the same)
-- `nz::Int` image size is `[nx,nx,nz]`
-- `px::Int`
+- `nx::Int = 128` (`ny` implicitly the same)
+- `nz::Int = nx` image size is `[nx,nx,nz]`
+- `px::Int = 1`
 - `pz::Int = px` (PSF size)
 - `padsize::Tuple` : `(padup, paddown, padleft, padright)`
 - `workmat [nx+padup+paddown, nz+padleft+padright]` 2D padded image for FFT convolution
@@ -36,10 +36,10 @@ struct PlanPSF{T, Tf, Ti}
     fft_plan::Tf # Union{AbstractFFTs.ScaledPlan, FFTW.cFFTWPlan}
     ifft_plan::Ti # Union{AbstractFFTs.ScaledPlan, FFTW.cFFTWPlan}
 
-    function PlanPSF(
-        nx::Int,
-        nz::Int,
-        px::Int;
+    function PlanPSF( ;
+        nx::Int = 128,
+        nz::Int = nx,
+        px::Int = 1,
         pz::Int = px,
         T::DataType = Float32,
     )
@@ -84,28 +84,27 @@ end
 
 
 """
-    plan_psf(nx::Int, nz::Int, px::Int; pz::Int, nthread::Int, T::DataType)
+    plan_psf( ; nx::Int, nz::Int, px::Int, pz::Int, nthread::Int, T::DataType)
 Make Vector of structs for storing work arrays and factors
 for 2D convolution with SPECT depth-dependent PSF model,
 threaded across planes parallel to detector.
-Input
-- `nx::Int`
-- `nz::Int`
-- `px::Int`
 Option
+- `nx::Int = 128`
+- `nz::Int = nx`
+- `px::Int = 1`
+- `pz::Int = px` PSF size is `px × pz`
 - `T` : datatype of work arrays, defaults to `Float32`
 - `nthread::Int` # of threads, defaults to `Threads.nthreads()`
-- `pz::Int = px` PSF size
 """
-function plan_psf(
-    nx::Int,
-    nz::Int,
-    px::Int;
+function plan_psf( ;
+    nx::Int = 128,
+    nz::Int = nx,
+    px::Int = 1,
     pz::Int = px,
     nthread::Int = Threads.nthreads(),
     T::DataType = Float32,
 )
-    return [PlanPSF(nx, nz, px; pz, T) for id = 1:nthread]
+    return [PlanPSF( ; nx, nz, px, pz, T) for id = 1:nthread]
 end
 
 

--- a/src/project.jl
+++ b/src/project.jl
@@ -187,7 +187,7 @@ Option
 function project(
     image::AbstractArray{<:RealU, 3},
     mumap::AbstractArray{<:RealU, 3}, # [nx,ny,nz] 3D attenuation map
-    psfs::AbstractArray{<:RealU, 4}, # [nx_psf,nx_psf,ny,nview]
+    psfs::AbstractArray{<:RealU, 4}, # [px,pz,ny,nview]
     dy::RealU;
     interpmeth::Symbol = :two,
     mode::Symbol = :fast,

--- a/src/project.jl
+++ b/src/project.jl
@@ -18,17 +18,19 @@ function project!(
     Threads.@threads for z = 1:plan.imgsize[3] # 1:nz
         thid = Threads.threadid() # thread id
         # rotate image in plan.imgr
-        imrotate!((@view plan.imgr[:, :, z]),
-                  (@view image[:, :, z]),
-                  plan.viewangle[viewidx],
-                  plan.planrot[thid],
-                  )
+        imrotate!(
+            (@view plan.imgr[:, :, z]),
+            (@view image[:, :, z]),
+            plan.viewangle[viewidx],
+            plan.planrot[thid],
+        )
         # rotate mumap and store in plan.mumapr
-        imrotate!((@view plan.mumapr[:, :, z]),
-                  (@view plan.mumap[:, :, z]),
-                  plan.viewangle[viewidx],
-                  plan.planrot[thid],
-                  )
+        imrotate!(
+            (@view plan.mumapr[:, :, z]),
+            (@view plan.mumap[:, :, z]),
+            plan.viewangle[viewidx],
+            plan.planrot[thid],
+        )
     end
 
     Threads.@threads for y = 1:plan.imgsize[2] # 1:ny
@@ -47,11 +49,12 @@ function project!(
         # apply depth-dependent attenuation
         mul3dj!(plan.imgr, plan.exp_mumapr[thid], y)
 
-        fft_conv!((@view plan.add_img[:, y, :]),
-                  (@view plan.imgr[:, y, :]),
-                  (@view plan.psfs[:, :, y, viewidx]),
-                  plan.planpsf[thid],
-                  )
+        fft_conv!(
+            (@view plan.add_img[:, y, :]),
+            (@view plan.imgr[:, y, :]),
+            (@view plan.psfs[:, :, y, viewidx]),
+            plan.planpsf[thid],
+        )
     end
 
     copy3dj!(view, plan.add_img, 1) # initialize accumulator
@@ -81,17 +84,19 @@ function project!(
 
     for z = 1:plan.imgsize[3] # 1:nz
         # rotate image in plan.imgr
-        imrotate!((@view plan.imgr[thid][:, :, z]),
-                  (@view image[:, :, z]),
-                  plan.viewangle[viewidx],
-                  plan.planrot[thid],
-                  )
+        imrotate!(
+            (@view plan.imgr[thid][:, :, z]),
+            (@view image[:, :, z]),
+            plan.viewangle[viewidx],
+            plan.planrot[thid],
+        )
         # rotate mumap and store in plan.mumapr
-        imrotate!((@view plan.mumapr[thid][:, :, z]),
-                  (@view plan.mumap[:, :, z]),
-                  plan.viewangle[viewidx],
-                  plan.planrot[thid],
-                  )
+        imrotate!(
+            (@view plan.mumapr[thid][:, :, z]),
+            (@view plan.mumap[:, :, z]),
+            plan.viewangle[viewidx],
+            plan.planrot[thid],
+        )
     end
 
     for y = 1:plan.imgsize[2] # 1:ny
@@ -109,11 +114,12 @@ function project!(
         # apply depth-dependent attenuation
         mul3dj!(plan.imgr[thid], plan.exp_mumapr[thid], y)
 
-        fft_conv!((@view plan.add_img[thid][:, y, :]),
-                  (@view plan.imgr[thid][:, y, :]),
-                  (@view plan.psfs[:, :, y, viewidx]),
-                  plan.planpsf[thid],
-                  )
+        fft_conv!(
+            (@view plan.add_img[thid][:, y, :]),
+            (@view plan.imgr[thid][:, y, :]),
+            (@view plan.psfs[:, :, y, viewidx]),
+            plan.planpsf[thid],
+        )
 
     end
 
@@ -177,17 +183,17 @@ Convenience method for SPECT forward projector that does all allocation
 including initializing `plan`.
 
 In
-* `image` : 3D array `[nx,ny,nz]`
-* `mumap` : `[nx,ny,nz]` 3D attenuation map, possibly zeros()
+* `image` : 3D array `(nx,ny,nz)`
+* `mumap` : `(nx,ny,nz)` 3D attenuation map, possibly zeros()
 * `psfs` : 4D PSF array
 * `dy::RealU` : pixel size
 Option
-* `interpmeth` : :one or :two
+* `interpmeth` : `:one` or `:two`
 """
 function project(
     image::AbstractArray{<:RealU, 3},
-    mumap::AbstractArray{<:RealU, 3}, # [nx,ny,nz] 3D attenuation map
-    psfs::AbstractArray{<:RealU, 4}, # [px,pz,ny,nview]
+    mumap::AbstractArray{<:RealU, 3}, # (nx,ny,nz) 3D attenuation map
+    psfs::AbstractArray{<:RealU, 4}, # (px,pz,ny,nview)
     dy::RealU;
     interpmeth::Symbol = :two,
     mode::Symbol = :fast,

--- a/src/psf-gauss.jl
+++ b/src/psf-gauss.jl
@@ -49,7 +49,7 @@ function psf_gauss(r::AbstractVector, fwhm::Real)
         any(==(0), r) || throw("must have some r=0 if fwhm=0")
         return r .== 0 # Kronecker impulse
    end
-   σ = fwhm / sqrt(log(256))
-   psf = @. exp(-π * abs2(r / σ))
+   σ = fwhm / sqrt(log(256)) # FWHM to Gaussian σ
+   psf = @. exp(-0.5 * abs2(r / σ))
    return psf / sum(psf)
 end

--- a/src/rotatez.jl
+++ b/src/rotatez.jl
@@ -10,7 +10,8 @@ using LinearInterpolators: TwoDimensionalTransformInterpolator
 
 """
     linearinterp!(A, s, e, len)
-Assign key values in `SparseInterpolator` (linear) `A` that are calculated from `s`, `e` and `len`.
+Assign key values in `SparseInterpolator` (linear) `A`
+that are calculated from `s`, `e` and `len`.
 `s` means start (x[1])
 `e` means end (x[end])
 `len` means length (length(x))
@@ -66,7 +67,7 @@ function rotate_x!(
         s = (idx[i] - c_y) * tan_θ + 1
         e = (idx[i] - c_y) * tan_θ + len
         linearinterp!(interp, s, e, len)
-        mul!((@view output[:, i]), interp, (@view img[:, i])) # need mul! to avoid allocating
+        mul!((@view output[:, i]), interp, (@view img[:, i]))
     end
     return output
 end
@@ -90,7 +91,7 @@ function rotate_x_adj!(
         s = (idx[i] - c_y) * tan_θ + 1
         e = (idx[i] - c_y) * tan_θ + len
         linearinterp!(interp, s, e, len)
-        mul!((@view output[:, i]), interp', (@view img[:, i])) # need mul! to avoid allocating
+        mul!((@view output[:, i]), interp', (@view img[:, i]))
     end
     return output
 end
@@ -253,21 +254,23 @@ function imrotate!(
     N = size(img, 1) # M = N!
 
     if θ ≈ m * (π/2)
-        padzero!(plan.workmat2, img, (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
+        padzero!(plan.workmat2, img,
+            (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
         rot_f90!(plan.workmat1, plan.workmat2, m)
     else
         mod_theta = θ - m * (π/2) # make sure it is between -45 and 45 degree
         tan_mod_theta = tan(mod_theta / 2)
         sin_mod_theta = - sin(mod_theta)
-        padzero!(plan.workmat1, img, (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
+        padzero!(plan.workmat1, img,
+            (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
         rot_f90!(plan.workmat2, plan.workmat1, m)
         rotate_x!(plan.workmat1, plan.workmat2, tan_mod_theta, plan.interp)
         rotate_y!(plan.workmat2, plan.workmat1, sin_mod_theta, plan.interp)
         rotate_x!(plan.workmat1, plan.workmat2, tan_mod_theta, plan.interp)
     end
 
-    output .= (@view plan.workmat1[plan.padsize + 1 : plan.padsize + N,
-                                   plan.padsize + 1 : plan.padsize + N])
+    output .= (@view plan.workmat1[plan.padsize .+ (1:N),
+                                   plan.padsize .+ (1:N)])
 
     return output
 end
@@ -297,20 +300,22 @@ function imrotate_adj!(
     N = size(img, 1) # M = N!
 
     if θ ≈ m * (π/2)
-        padzero!(plan.workmat2, img, (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
+        padzero!(plan.workmat2, img,
+            (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
         rot_f90_adj!(plan.workmat1, plan.workmat2, m)
     else
         mod_theta = θ - m * (π/2) # make sure it is between -45 and 45 degree
         tan_mod_theta = tan(mod_theta / 2)
         sin_mod_theta = - sin(mod_theta)
-        padzero!(plan.workmat1, img, (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
+        padzero!(plan.workmat1, img,
+            (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
         rotate_x_adj!(plan.workmat2, plan.workmat1, tan_mod_theta, plan.interp)
         rotate_y_adj!(plan.workmat1, plan.workmat2, sin_mod_theta, plan.interp)
         rotate_x_adj!(plan.workmat2, plan.workmat1, tan_mod_theta, plan.interp)
         rot_f90_adj!(plan.workmat1, plan.workmat2, m) # must be two different arguments
     end
-    output .= (@view plan.workmat1[plan.padsize + 1 : plan.padsize + N,
-                                   plan.padsize + 1 : plan.padsize + N])
+    output .= (@view plan.workmat1[plan.padsize .+ (1:N),
+                                   plan.padsize .+ (1:N)])
     return output
 end
 
@@ -345,11 +350,12 @@ function imrotate!(
     R = c + rotate(2π - θ, AffineTransform2D{T}() - c)
     A = TwoDimensionalTransformInterpolator(rows, cols, ker, R)
 
-    padzero!(plan.workmat1, img, (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
+    padzero!(plan.workmat1, img,
+        (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
     mul!(plan.workmat2, A, plan.workmat1)
 
-    output .= (@view plan.workmat2[plan.padsize + 1 : plan.padsize + N,
-                                   plan.padsize + 1 : plan.padsize + N])
+    output .= (@view plan.workmat2[plan.padsize .+ (1:N),
+                                   plan.padsize .+ (1:N)])
     return output
 end
 
@@ -398,11 +404,12 @@ function imrotate_adj!(
     R = c + rotate(2π - θ, AffineTransform2D{T}() - c)
     A = TwoDimensionalTransformInterpolator(rows, cols, ker, R)
 
-    padzero!(plan.workmat1, img, (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
+    padzero!(plan.workmat1, img,
+        (plan.padsize, plan.padsize, plan.padsize, plan.padsize))
     mul!(plan.workmat2, A', plan.workmat1) # todo: internals of A' ?
 
-    output .= (@view plan.workmat2[plan.padsize + 1 : plan.padsize + N,
-                                   plan.padsize + 1 : plan.padsize + N])
+    output .= (@view plan.workmat2[plan.padsize .+ (1:N),
+                                   plan.padsize .+ (1:N)])
     return output
 end
 

--- a/src/spectplan.jl
+++ b/src/spectplan.jl
@@ -48,7 +48,6 @@ struct SPECTplan{T}
     nthread::Int # number of threads
     planrot::Vector{PlanRotate}
     planpsf::Vector{PlanPSF}
-    # other options for how to do the projection?
 
     """
         SPECTplan(mumap, psfs, dy; T, viewangle, interpmeth, nthread, mode)
@@ -110,28 +109,27 @@ struct SPECTplan{T}
 
         planrot = plan_rotate(nx; T, method = interpmeth)
 
-        planpsf = plan_psf(nx, nz, px; pz, nthread = nthread, T = T)
+        planpsf = plan_psf(; nx, nz, px, pz, nthread, T)
 
         new{T}(T, # default type for work arrays etc.
-               imgsize,
-               px,
-               pz,
-               imgr, # 3D rotated image, (nx, ny, nz)
-               add_img,
-               mumap, # [nx,ny,nz] attenuation map, must be 3D, possibly zeros()
-               mumapr, # 3D rotated mumap, (nx, ny, nz)
-               exp_mumapr,
-               psfs, # PSFs must be 4D, [px, pz, ny, nview], finally be centered psf
-               nview, # number of views
-               viewangle,
-               interpmeth,
-               mode,
-               dy,
-               nthread, # number of threads
-               planrot,
-               planpsf,
+            imgsize,
+            px,
+            pz,
+            imgr, # 3D rotated image, (nx, ny, nz)
+            add_img,
+            mumap, # [nx,ny,nz] attenuation map, must be 3D, possibly zeros()
+            mumapr, # 3D rotated mumap, (nx, ny, nz)
+            exp_mumapr,
+            psfs, # PSFs must be 4D, [px, pz, ny, nview], finally be centered psf
+            nview, # number of views
+            viewangle,
+            interpmeth,
+            mode,
+            dy,
+            nthread, # number of threads
+            planrot,
+            planpsf,
         )
-         # creates objects of the block's type (inner constructor methods).
     end
 end
 

--- a/test/adjoint-project.jl
+++ b/test/adjoint-project.jl
@@ -17,9 +17,9 @@ using Test: @test, @testset
 
     mumap = rand(T, nx, ny, nz)
 
-    nx_psf = 3
-    nz_psf = 3
-    psfs = rand(T, nx_psf, nz_psf, ny, nview)
+    px = 3
+    pz = 3 # todo
+    psfs = rand(T, px, pz, ny, nview)
     psfs = psfs .+ mapslices(reverse, psfs, dims = [1, 2]) # symmetrize
     psfs = psfs .+ mapslices(transpose, psfs, dims = [1, 2]) # symmetrize
     psfs = psfs ./ mapslices(sum, psfs, dims = [1, 2])
@@ -58,9 +58,9 @@ end
 
     mumap = rand(T, nx, ny, nz)
 
-    nx_psf = 7
-    nz_psf = 7
-    psfs = rand(T, nx_psf, nz_psf, ny, nview)
+    px = 7
+    pz = 7 # todo
+    psfs = rand(T, px, pz, ny, nview)
     psfs = psfs .+ mapslices(reverse, psfs, dims = [1, 2])
     psfs = psfs .+ mapslices(transpose, psfs, dims = [1, 2]) # symmetrize
     psfs = psfs ./ mapslices(sum, psfs, dims = [1, 2])

--- a/test/adjoint-project.jl
+++ b/test/adjoint-project.jl
@@ -17,11 +17,10 @@ using Test: @test, @testset
 
     mumap = rand(T, nx, ny, nz)
 
-    px = 3
-    pz = 3 # todo
+    px = 5
+    pz = 3
     psfs = rand(T, px, pz, ny, nview)
     psfs = psfs .+ mapslices(reverse, psfs, dims = [1, 2]) # symmetrize
-    psfs = psfs .+ mapslices(transpose, psfs, dims = [1, 2]) # symmetrize
     psfs = psfs ./ mapslices(sum, psfs, dims = [1, 2])
 
     dy = T(4.7952)
@@ -58,11 +57,10 @@ end
 
     mumap = rand(T, nx, ny, nz)
 
-    px = 7
-    pz = 7 # todo
+    px = 5
+    pz = 3
     psfs = rand(T, px, pz, ny, nview)
     psfs = psfs .+ mapslices(reverse, psfs, dims = [1, 2])
-    psfs = psfs .+ mapslices(transpose, psfs, dims = [1, 2]) # symmetrize
     psfs = psfs ./ mapslices(sum, psfs, dims = [1, 2])
 
     dy = T(4.7952)

--- a/test/fftconv.jl
+++ b/test/fftconv.jl
@@ -10,7 +10,7 @@ using Test: @test, @testset, @test_throws, @inferred
 
 
 @testset "plan_psf" begin
-    plan = plan_psf(10, 10, 5)
+    plan = plan_psf( ; nx=10, px=5)
     show(isinteractive() ? stdout : devnull, "text/plain", plan)
     show(isinteractive() ? stdout : devnull, "text/plain", plan[1])
     @test sizeof(plan) isa Int
@@ -33,9 +33,9 @@ end
     nx = 12
     nz = 10
     px = 5
-    pz = 5 # todo
+    pz = 3
     T = Float32
-    plan = plan_psf(nx, nz, px; T)
+    plan = plan_psf( ; nx, nz, px, pz, T)
     image3 = rand(T, nx, nx, nz)
     ker3 = ones(T, px, pz, nx) / (px*pz)
     result = similar(image3)

--- a/test/fftconv.jl
+++ b/test/fftconv.jl
@@ -32,11 +32,12 @@ end
 @testset "fftconv3" begin
     nx = 12
     nz = 10
-    nx_psf = 5
+    px = 5
+    pz = 5 # todo
     T = Float32
-    plan = plan_psf(nx, nz, nx_psf; T)
+    plan = plan_psf(nx, nz, px; T)
     image3 = rand(T, nx, nx, nz)
-    ker3 = ones(T, nx_psf, nx_psf, nx) / (nx_psf)^2
+    ker3 = ones(T, px, pz, nx) / (px*pz)
     result = similar(image3)
     fft_conv!(result, image3, ker3, plan)
     @test maximum(result) ≤ 1

--- a/test/helper.jl
+++ b/test/helper.jl
@@ -7,7 +7,7 @@ using SPECTrecon: plus3di!, plus3dj!, plus3dk!, scale3dj!, mul3dj!
 using SPECTrecon: copy3dj!
 using ImageFiltering: Fill, Pad, BorderArray
 import OffsetArrays
-using Test: @test, @testset
+using Test: @test, @testset, @inferred
 
 
 @testset "padzero!" begin
@@ -16,7 +16,7 @@ using Test: @test, @testset
     y = randn(T, 3, 3)
     padzero!(x, y, (2, 2, 1, 1))
     z = OffsetArrays.no_offset_view(BorderArray(y, Fill(0, (2, 1), (2, 1))))
-    @test isequal(x, z)
+    @test x == z
 end
 
 
@@ -26,129 +26,136 @@ end
     y = randn(T, 5, 4)
     padrepl!(x, y, (1, 4, 3, 2)) # up, down, left, right
     z = OffsetArrays.no_offset_view(BorderArray(y, Pad(:replicate, (1, 3), (4, 2)))) # up, left, down, right
-    @test isequal(x, z)
+    @test x == z
 end
 
 
 @testset "pad2size!" begin
     T = Float32
-    ker = reshape(Int16(1):Int16(9), 3, 3)
-    padsize = (8, 8)
+    ker = reshape(Int16(1):Int16(15), 5, 3)
+    padsize = (8, 6)
     z = randn(T, padsize)
     pad2sizezero!(z, ker, padsize)
-    tmp = pad_it!(ker, padsize)
-    @test isequal(tmp, z)
+    tmp = @inferred pad_it!(ker, padsize)
+    @test tmp == z
 end
 
 
 @testset "fftshift" begin
     T = Float32
-    x = randn(T, 120, 128)
+    x = randn(T, 10, 12)
     y = similar(x)
     z = similar(x)
-    fftshift!(y, x)
+    @inferred fftshift!(y, x)
     @test ifftshift!(z, y) == x
-    fftshift2!(z, x)
-    @test isequal(y, z)
+    @inferred fftshift2!(z, x)
+    @test y == z
+
+    x = randn(T, 12, 1) # "1D" case
+    y = similar(x)
+    z = similar(x)
+    @inferred fftshift2!(y, x)
+    @inferred fftshift2!(z, y)
+    @test x == z
 end
 
 
 @testset "plus1di" begin
     T = Float32
-    x = randn(T, 4, 64)
-    v = randn(T, 64)
+    x = randn(T, 4, 9)
+    v = randn(T, 9)
     y = x[2, :] .+ v
     plus1di!(x, v, 2)
-    @test isequal(x[2, :], y)
+    @test x[2, :] == y
 end
 
 
 @testset "plus1dj!" begin
     T = Float32
-    x = randn(T, 64, 4)
-    v = randn(T, 64)
+    x = randn(T, 9, 4)
+    v = randn(T, 9)
     y = x[:, 2] .+ v
     plus1dj!(x, v, 2)
-    @test isequal(x[:, 2], y)
+    @test x[:, 2] == y
 end
 
 
 @testset "plus2di!" begin
     T = Float32
-    x = randn(64)
-    v = randn(4, 64)
+    x = randn(9)
+    v = randn(4, 9)
     y = x .+ v[2, :]
     plus2di!(x, v, 2)
-    @test isequal(x, y)
+    @test x == y
 end
 
 
 @testset "plus2dj!" begin
     T = Float32
-    x = randn(T, 64)
-    v = randn(T, 64, 4)
+    x = randn(T, 9)
+    v = randn(T, 9, 4)
     y = x .+ v[:, 2]
     plus2dj!(x, v, 2)
-    @test isequal(x, y)
+    @test x == y
 end
 
 
 @testset "plus3di!" begin
     T = Float32
-    x = randn(T, 64, 64)
-    v = randn(T, 4, 64, 64)
+    x = randn(T, 9, 7)
+    v = randn(T, 4, 9, 7)
     y = x .+ v[2, :, :]
     plus3di!(x, v, 2)
-    @test isequal(x, y)
+    @test x == y
 end
 
 
 @testset "plus3dj!" begin
     T = Float32
-    x = randn(T, 64, 64)
-    v = randn(T, 64, 4, 64)
+    x = randn(T, 9, 7)
+    v = randn(T, 9, 4, 7)
     y = x .+ v[:, 2, :]
     plus3dj!(x, v, 2)
-    @test isequal(x, y)
+    @test x == y
 end
 
 
 @testset "plus3dk!" begin
     T = Float32
-    x = randn(T, 64, 64)
-    v = randn(T, 64, 64, 4)
+    x = randn(T, 9, 7)
+    v = randn(T, 9, 7, 4)
     y = x .+ v[:, :, 2]
     plus3dk!(x, v, 2)
-    @test isequal(x, y)
+    @test x == y
 end
 
 
 @testset "scale3dj!" begin
     T = Float32
-    x = randn(T, 64, 64)
-    v = randn(T, 64, 4, 64)
+    x = randn(T, 9, 7)
+    v = randn(T, 9, 4, 7)
     s = -0.5
     y = s * v[:, 2, :]
     scale3dj!(x, v, 2, s)
-    @test isequal(x, y)
+    @test x == y
 end
 
 
 @testset "mul3dj!" begin
     T = Float32
-    x = randn(T, 64, 4, 64)
-    v = randn(T, 64, 64)
+    x = randn(T, 9, 4, 7)
+    v = randn(T, 9, 7)
     y = x[:,2,:] .* v
     mul3dj!(x, v, 2)
-    @test isequal(x[:,2,:], y)
+    @test x[:,2,:] == y
 end
 
 
 @testset "copy3dj!" begin
     T = Float32
-    x = randn(T, 64, 64)
-    v = randn(T, 64, 4, 64)
+    x = randn(T, 9, 7)
+    v = randn(T, 9, 4, 7)
     y = v[:,2,:]
     copy3dj!(x, v, 2)
-    @test isequal(x, y)
+    @test x == y
 end

--- a/test/psf-gauss.jl
+++ b/test/psf-gauss.jl
@@ -7,4 +7,25 @@ using Test: @test, @testset, @test_throws, @inferred
 @testset "psf" begin
     psf = @inferred psf_gauss()
     @test psf isa Array{Float32,3}
+
+    ny = 4
+    px = 5
+    pz = 3
+    psf = @inferred psf_gauss(; ny, px, pz, fwhm = zeros(ny))
+    tmp = zeros(px,pz)
+    tmp[(end+1)÷2,(end+1)÷2] = 1 # Kronecker impulse
+    tmp = repeat(tmp, 1, 1, ny)
+    @test psf == tmp
+
+    ny = 4
+    px = 5
+    pz = 3
+    psf = @inferred psf_gauss(; ny, px, pz,
+        fwhm_x = fill(Inf, ny),
+        fwhm_z = zeros(ny),
+    )
+    tmp = zeros(px,pz)
+    tmp[:,(end+1)÷2] .= 1/px # wide in x
+    tmp = repeat(tmp, 1, 1, ny)
+    @test psf ≈ tmp
 end


### PR DESCRIPTION
PSF size is `px` by `pz`.
The motivation is to enable "2D" SPECT simulations where `pz=1`.
There are some small "breaking" changes here in the plan.
